### PR TITLE
Needs more quotes (at least for CMake 2.8)

### DIFF
--- a/templates/project.yaml
+++ b/templates/project.yaml
@@ -8,7 +8,7 @@ name: '{{project_name}}'
 # Build task
 # ----------
 # Comma-separated list of command line arguments passed to cmake
-cmake-args: ['-G Unix Makefiles',
+cmake-args: ['-G "Unix Makefiles"',
              '-DCMAKE_BUILD_TYPE=RelWithDebInfo']
 
 # Comma-separated list of arguments passed to cmake --build


### PR DESCRIPTION
`obi build` failed on Ubuntu 12.04 with CMake 2.8.  Adding the quotes around `Unix Makefiles` fixes it, but I'm curious if this works fine on newer versions of CMake.